### PR TITLE
Refactored the text truncation function

### DIFF
--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -3426,25 +3426,33 @@
             if (options.dash) { this._PDF.undash(); }
         },
 
-        _truncateText: function (data, width) {
-            var curData;
-            var offset = data.data.indexOf('\n');
-            if (offset > 0) {
-                curData = data.data.substr(0, offset);
-            } else {
-                curData = data.data;
+        _truncateText: function (data, width, lineData) {
+            width -= this.widthOfString('M'); // Due to rendering differences, purposefully subtract a wide character from the width. (1 em)
+            var string = data.data,
+                firstNewline = data.data.indexOf('\n');
+            if (firstNewline !== -1) {
+                string = data.data.substr(0, firstNewline);
             }
-            var wos = this.widthOfString(curData);
+            var wos = this.widthOfString(string),
+                newWos,
+                newString = string;
             if (wos >= width) {
-                var len = 1;
-                while (wos >= width && len > 0) {
-                    var wos_c = parseInt(wos / width, 10) + 1;
-                    len = parseInt(curData.length / wos_c, 10) - 1;
-                    curData = curData.substr(0, len);
-                    wos = this.widthOfString(curData);
+                var posStart = 0, posMid, posEnd = string.length, posLength;
+                while (posLength = (posEnd - posStart) >> 1) {
+                    posMid = posStart + posLength;
+                    newString = string.substring(0, posMid);
+
+                    // Check if the current width is too wide (set new end) or too narrow (set new start)
+                    newWos = this.widthOfString(newString);
+                    if (newWos >= width) {
+                        posEnd = Math.floor(posMid);
+                    } else {
+                        posStart = Math.ceil(posMid);
+                    }
                 }
+                string = newString;
             }
-            data.data = curData;
+            data.data = string;
             return 1;
         },
 

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -3426,7 +3426,7 @@
             if (options.dash) { this._PDF.undash(); }
         },
 
-        _truncateText: function (data, width, lineData) {
+        _truncateText: function (data, width) {
             width -= this.widthOfString('M'); // Due to rendering differences, purposefully subtract a wide character from the width. (1 em)
             var string = data.data,
                 firstNewline = data.data.indexOf('\n');

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -3428,10 +3428,12 @@
 
         _truncateText: function (data, width) {
             width -= this.widthOfString('M'); // Due to rendering differences, purposefully subtract a wide character from the width. (1 em)
-            var string = data.data,
+            var string,
                 firstNewline = data.data.indexOf('\n');
             if (firstNewline !== -1) {
                 string = data.data.substr(0, firstNewline);
+            } else {
+                string = data.data;
             }
             var wos = this.widthOfString(string),
                 newWos,


### PR DESCRIPTION
Text truncation was very inaccurate under certain circumstances. The
position that it truncated to would vary greatly, sometimes cutting off
way too early, leaving up to half of the available space blank.

This resolves that by using a bitwise operator to adjust to the desired
length efficiently. It calculates the middle position for each loop,
and adjusts based on that.

It should be efficient, and accurate. Unfortunately due to some quirks
in the rendering process, I had to subtract 1 em (“M”) from the
available width to prevent certain characters from overflowing. This
results in a little bit less space used than is available, but the end
result is much better than the previous version.