### PR TITLE
Fix various wrapping bugs

### DIFF
--- a/lib/PDFKitImportPDF.js
+++ b/lib/PDFKitImportPDF.js
@@ -32,7 +32,7 @@
  * @license MIT
  */
 
-var pdfkit = require('pdfkit');
+var pdfkit = require('@darkguardace/pdfkit');
 
 
 /**

--- a/lib/PDFKitImportPDF.js
+++ b/lib/PDFKitImportPDF.js
@@ -32,7 +32,7 @@
  * @license MIT
  */
 
-var pdfkit = require('@darkguardace/pdfkit');
+var pdfkit = require('pdfkit');
 
 
 /**

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -220,6 +220,18 @@
         }
         console.error.apply(console, arguments);
     }
+    
+    /**
+     * @class ReportError
+     * @desc This is a constructor for error details that are returned by fluentreports
+     * @param detail object, generally including some mix of error, error.stack, and an error code
+     * @constructor
+     */
+    function ReportError(detailsObject) {
+      for (var key in detailsObject) {
+        this[key] = detailsObject[key];
+      }
+    }
 
     /**
      * This is a callback that just prints any errors, used for places a callback may not have been passed in.
@@ -819,7 +831,7 @@
                         } else if (!this._savedFirstMove) {
                             opt.addY = 0;
                             opt.y = 0;
-                            Report.error("REPORTAPI: Your footer starts with printing some text, then uses an absolute move of greater than a third of the page. Please move first, then print!", '', '', 33);
+                            Report.error("REPORTAPI: Your footer starts with printing some text, then uses an absolute move of greater than a third of the page. Please move first, then print!");
                         }
                     }
 
@@ -1335,18 +1347,18 @@
                                 }
                                 if (err) {
                                     if (self._isHeader) {
-                                        Report.error("REPORTAPI: Error running header in report", err, err && err.stack);
+                                        Report.error("REPORTAPI: Error running header in report", new ReportError({error: err, stack: err && err.stack}));
                                     } else {
-                                        Report.error("REPORTAPI: Error running footer in report", err, err && err.stack);
+                                        Report.error("REPORTAPI: Error running footer in report", new ReportError({error: err, stack: err && err.stack}));
                                     }
                                 }
                                 _handlePostPageBreak();
                             });
                         } catch (err) {
                             if (self._isHeader) {
-                                Report.error("REPORTAPI: Error running header in report", err, err && err.stack);
+                                Report.error("REPORTAPI: Error running header in report", new ReportError({error: err, stack: err && err.stack}));
                             } else {
-                                Report.error("REPORTAPI: Error running footer in report", err, err && err.stack);
+                                Report.error("REPORTAPI: Error running footer in report", new ReportError({error: err, stack: err && err.stack}));
                             }
                             _handlePostPageBreak();
                         }
@@ -1355,9 +1367,9 @@
                             self._part(Rpt, Data, State);
                         } catch (err) {
                             if (self._isHeader) {
-                                Report.error("REPORTAPI: Error running header in report", err, err && err.stack);
+                                Report.error("REPORTAPI: Error running header in report", new ReportError({error: err, stack: err && err.stack}));
                             } else {
-                                Report.error("REPORTAPI: Error running footer in report", err, err && err.stack);
+                                Report.error("REPORTAPI: Error running footer in report", new ReportError({error: err, stack: err && err.stack}));
                             }
                         }
                         if (Report.trace && Report.callbackDebugging) {
@@ -1393,7 +1405,7 @@
                         }
                         if (Rpt.getCurrentY() > Rpt.maxY()) {
                             var exceeds = parseInt(Math.ceil(Rpt.getCurrentY()),10) - Rpt.maxY();
-                            Report.error("REPORTAPI: Your Report's Page Footer exceeds the page bottom margin (" + Rpt.maxY() + ") by " + exceeds + "-- Please subtract" + exceeds + "pixels from (probably) where you set Y to" + (Rpt._savedFirstMove ? Rpt._savedFirstMove : "change its location."));
+                            Report.error("REPORTAPI: Your Report's Page Footer exceeds the page bottom margin (", Rpt.maxY(), ") by ", exceeds, "-- Please subtract", exceeds, "pixels from (probably) where you set Y to", (Rpt._savedFirstMove ? Rpt._savedFirstMove : "change its location."));
                         }
                     }
                     if (Report.trace) {
@@ -1822,7 +1834,7 @@
 
                 this._heightOfString = this._PDF.currentLineHeight(true);
             } catch (err) {
-                Report.error("REPORTAPI: Invalid font" + name);
+                Report.error("REPORTAPI: Invalid font", name);
             }
         },
 
@@ -3645,7 +3657,7 @@
             if (this._reportRenderMode === reportRenderingMode.ASYNC) {
                 if (typeof callback !== 'function') {
                     var e = new Error();
-                    Report.error("REPORTAPI: You have called a ASYNCHRONOUS function" + functionName.toUpperCase() + "without the callback, the report WILL have issues or might even throw an error while saving.  The error and callstack are as follows:", e, e && e.stack);
+                    Report.error("REPORTAPI: You have called a ASYNCHRONOUS function", functionName.toUpperCase(), "without the callback, the report WILL have issues or might even throw an error while saving.  The error and callstack are as follows:", new ReportError({error: e, stack: e && e.stack}));
                 }
             } /* else if (this._reportRenderMode === reportRenderingMode.SYNC) {
                 if (typeof callback === 'function') {
@@ -3829,7 +3841,7 @@
             var renderData = function (err, data) {
 
                 if (err) {
-                    Report.error("REPORTAPI: Error in rendering data: ", err);
+                    Report.error("REPORTAPI: Error in rendering data: ", new ReportError({error: err}));
                     callback(err);
                     return;
                 }
@@ -3914,12 +3926,12 @@
                     self._data.count(
                         function (err, length) {
                             if (err) {
-                                Report.error("REPORTAPI: Got error getting count: ", err);
+                                Report.error("REPORTAPI: Got error getting count: ", new ReportError({error: err}));
                                 length = 0;
                             }
 
                             if (isNaN(length)) {
-                                Report.error("REPORTAPI: Got a non-number row length/count" + length);
+                                Report.error("REPORTAPI: Got a non-number row length/count", length);
                                 length = 0;
                             }
 
@@ -3954,7 +3966,7 @@
                 var handleCb = false;
                 var data = this._data(this._buildKeySet(currentData), function(err, ndata) {
                     if (err) {
-                        Report.error("REPORTAPI: Error getting data", err);
+                        Report.error("REPORTAPI: Error getting data", new ReportError({error: err}));
                         ndata = [];
                     }
                     if (!handleCb) {
@@ -4785,7 +4797,7 @@
                         this._totals[field]++;
                         break;
                     default:
-                        Report.error("REPORTAPI: Math expression id is wrong" + this._math[i][0] + " on " + field);
+                        Report.error("REPORTAPI: Math expression id is wrong", this._math[i][0], " on ", field);
                 }
             }
         },
@@ -4808,14 +4820,14 @@
                 if (curMode === reportRenderingMode.UNDEFINED) {
                     this._reportRenderMode(reportRenderingMode.ASYNC);
                 } else if (curMode !== reportRenderingMode.ASYNC) {
-                    Report.error("REPORTAPI: You have attempted to add a ASYNCHRONOUS " + typeFunction.toUpperCase() + "function to a report that already has a SYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this" + typeFunction.toUpperCase() + "function and leaving the report SYNCHRONOUS!");
+                    Report.error("REPORTAPI: You have attempted to add a ASYNCHRONOUS ", typeFunction.toUpperCase(), "function to a report that already has a SYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this", typeFunction.toUpperCase(), "function and leaving the report SYNCHRONOUS!");
                     return false;
                 }
             } else {
                 if (curMode === reportRenderingMode.UNDEFINED) {
                     this._reportRenderMode(reportRenderingMode.SYNC);
                 } else if (curMode !== reportRenderingMode.SYNC) {
-                    Report.error("REPORTAPI: You have attempted to add a SYNCHRONOUS" + typeFunction.toUpperCase() + "function to a report that already has a ASYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this" + typeFunction.toUpperCase() + "function and leaving the report ASYNCHRONOUS!");
+                    Report.error("REPORTAPI: You have attempted to add a SYNCHRONOUS", typeFunction.toUpperCase(), "function to a report that already has a ASYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this", typeFunction.toUpperCase(), "function and leaving the report ASYNCHRONOUS!");
                     return false;
                 }
             }
@@ -4862,7 +4874,7 @@
                     var x = function (err, data) {
                         self._expandRowTree(data);
                         if (err) {
-                            Report.error("REPORTAPI: ---- ERROR:", err);
+                            Report.error("REPORTAPI: ---- ERROR:", new ReportError({error: err}));
                         }
                         Rpt.totals = data;
                         finishFooter();
@@ -4891,7 +4903,7 @@
                 this._detail(Rpt, currentData, State);
             }
             catch(err) {
-                Report.error("REPORTAPI: Error when calling group Detail", err, err && err.stack);
+                Report.error("REPORTAPI: Error when calling group Detail", new ReportError({error: err, stack: err && err.stack}));
             }
             // Callback is Required; so no "if" check
             callback();
@@ -4908,7 +4920,7 @@
         _renderAsyncDetail: function(Rpt, State, currentData, callback) {
             this._detail(Rpt, currentData, State, function(err) {
                 if(err) {
-                    Report.error("REPORTAPI: Error when calling group Detail", err, err && err.stack);
+                    Report.error("REPORTAPI: Error when calling group Detail", new ReportError({error: err, stack: err && err.stack}));
                 }
                 // Callback is Required; so no "if" check
                 callback();

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -1781,9 +1781,9 @@
 
         _PDFKit: _PDFKit,
 
-        _LineWrapperObject: require('@darkguardace/pdfkit/js/line_wrapper'),
+        _LineWrapperObject: require('pdfkit/js/line_wrapper'),
 
-        _PageObject: require('@darkguardace/pdfkit/js/page'),
+        _PageObject: require('pdfkit/js/page'),
 
         /***
          * Gets or sets the userdata

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -235,18 +235,6 @@
     }
 
     /**
-     * @class ReportError
-     * @desc This is a constructor for error details that are returned by fluentreports
-     * @param detail object, generally including some mix of error, error.stack, and an error code
-     * @constructor
-     */
-    function ReportError(detailsObject) {
-      for (var key in detailsObject) {
-        this[key] = detailsObject[key];
-      }
-    }
-
-    /**
      * This is a callback that just prints any errors, used for places a callback may not have been passed in.
      * @param err
      */

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -427,7 +427,20 @@
             currentLineHeight: function (val) { //noinspection JSPotentiallyInvalidUsageOfThis
                 return this._PDF.currentLineHeight(val); },
             widthOfString: function (d, o) { //noinspection JSPotentiallyInvalidUsageOfThis
-                return this._PDF.widthOfString(d, o); },
+                var splitString = d.split(' '),
+                    curWord,
+                    wos = 0,
+                    wordLength;
+                for (var i = 0; i < splitString.length; ++i) {
+                    curWord = splitString[i];
+                    if ((i + 1) !== splitString.length) {
+                        curWord += ' ';
+                    }
+                    wordLength = this._PDF.widthOfString(curWord, o);
+                    wos += wordLength;
+                }
+
+                return wos; },
             addPage: function () { this.pages++;
                 //noinspection JSPotentiallyInvalidUsageOfThis
                 this.x = this._PDF.page.margins.left;
@@ -2284,7 +2297,20 @@
          * @returns {number} size of string
          */
         widthOfString: function (str) {
-            return this._PDF.widthOfString(str);
+            var splitString = str.split(' '),
+                curWord,
+                wos = 0,
+                wordLength;
+            for (var i = 0; i < splitString.length; ++i) {
+                curWord = splitString[i];
+                if ((i + 1) !== splitString.length) {
+                    curWord += ' ';
+                }
+                wordLength = this._PDF.widthOfString(curWord);
+                wos += wordLength;
+            }
+
+            return wos;
         },
 
         /**

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -400,9 +400,9 @@
             for (var style in this._registeredFonts[key]) {
                 if (!this._registeredFonts[key].hasOwnProperty(style)) { continue; }
                 if (style === 'normal') {
-                    this._PDF.registerFont(key, this._registeredFonts[key][style], key);
+                    this._PDF.registerFont(key, this._registeredFonts[key][style]);
                 } else {
-                    this._PDF.registerFont(key+'-'+style, this._registeredFonts[key][style], key+'-'+style);
+                    this._PDF.registerFont(key+'-'+style, this._registeredFonts[key][style]);
                 }
 
             }

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -1769,9 +1769,9 @@
 
         _PDFKit: _PDFKit,
 
-        _LineWrapperObject: require('pdfkit/js/line_wrapper'),
+        _LineWrapperObject: require('@darkguardace/pdfkit/js/line_wrapper'),
 
-        _PageObject: require('pdfkit/js/page'),
+        _PageObject: require('@darkguardace/pdfkit/js/page'),
 
         /***
          * Gets or sets the userdata

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -2292,25 +2292,30 @@
         },
 
         /**
-         * Returns the width of the string
+         * Returns the width of the string, optionally checking width by word
          * @param {string} str
+         * @param {bool} checkByWord
          * @returns {number} size of string
          */
-        widthOfString: function (str) {
-            var splitString = str.split(' '),
-                curWord,
-                wos = 0,
-                wordLength;
-            for (var i = 0; i < splitString.length; ++i) {
-                curWord = splitString[i];
-                if ((i + 1) !== splitString.length) {
-                    curWord += ' ';
+        widthOfString: function (str, checkByWord) {
+            if (!checkByWord) {
+                return this._PDF.widthOfString(curWord);
+            } else {			
+                var splitString = str.split(' '),
+                    curWord,
+                    wos = 0,
+                    wordLength;
+                for (var i = 0; i < splitString.length; ++i) {
+                    curWord = splitString[i];
+                    if ((i + 1) !== splitString.length) {
+                        curWord += ' ';
+                    }
+                    wordLength = this._PDF.widthOfString(curWord);
+                    wos += wordLength;
                 }
-                wordLength = this._PDF.widthOfString(curWord);
-                wos += wordLength;
-            }
 
-            return wos;
+                return wos;
+            }
         },
 
         /**
@@ -3486,7 +3491,7 @@
             } else {
                 curData = data.data;
             }
-            var wos = this.widthOfString(curData);
+            var wos = this.widthOfString(curData, true);
             if (wos >= width) {
                 // Get avg character length
                 var wos_c = parseInt(wos / curData.length, 10) + 1;
@@ -3499,7 +3504,7 @@
 
                 do {
                     curData = newString.substr(0, len);
-                    wos = this.widthOfString(curData);
+                    wos = this.widthOfString(curData, true);
                     if (wos < width) {
                         optimalSize = len;
                         len++;

--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -819,7 +819,7 @@
                         } else if (!this._savedFirstMove) {
                             opt.addY = 0;
                             opt.y = 0;
-                            Report.error("REPORTAPI: Your footer starts with printing some text, then uses an absolute move of greater than a third of the page. Please move first, then print!");
+                            Report.error("REPORTAPI: Your footer starts with printing some text, then uses an absolute move of greater than a third of the page. Please move first, then print!", '', '', 33);
                         }
                     }
 
@@ -1393,7 +1393,7 @@
                         }
                         if (Rpt.getCurrentY() > Rpt.maxY()) {
                             var exceeds = parseInt(Math.ceil(Rpt.getCurrentY()),10) - Rpt.maxY();
-                            Report.error("REPORTAPI: Your Report's Page Footer exceeds the page bottom margin (",Rpt.maxY(),") by ", exceeds, "-- Please subtract",exceeds,"pixels from (probably) where you set Y to",Rpt._savedFirstMove ? Rpt._savedFirstMove : "change its location.");
+                            Report.error("REPORTAPI: Your Report's Page Footer exceeds the page bottom margin (" + Rpt.maxY() + ") by " + exceeds + "-- Please subtract" + exceeds + "pixels from (probably) where you set Y to" + (Rpt._savedFirstMove ? Rpt._savedFirstMove : "change its location."));
                         }
                     }
                     if (Report.trace) {
@@ -1822,7 +1822,7 @@
 
                 this._heightOfString = this._PDF.currentLineHeight(true);
             } catch (err) {
-                Report.error("REPORTAPI: Invalid font", name);
+                Report.error("REPORTAPI: Invalid font" + name);
             }
         },
 
@@ -3645,7 +3645,7 @@
             if (this._reportRenderMode === reportRenderingMode.ASYNC) {
                 if (typeof callback !== 'function') {
                     var e = new Error();
-                    Report.error("REPORTAPI: You have called a ASYNCHRONOUS function", functionName.toUpperCase(), "without the callback, the report WILL have issues or might even throw an error while saving.  The callstack is:", e.stack);
+                    Report.error("REPORTAPI: You have called a ASYNCHRONOUS function" + functionName.toUpperCase() + "without the callback, the report WILL have issues or might even throw an error while saving.  The error and callstack are as follows:", e, e && e.stack);
                 }
             } /* else if (this._reportRenderMode === reportRenderingMode.SYNC) {
                 if (typeof callback === 'function') {
@@ -3919,7 +3919,7 @@
                             }
 
                             if (isNaN(length)) {
-                                Report.error("REPORTAPI: Got a non-number row length/count", length);
+                                Report.error("REPORTAPI: Got a non-number row length/count" + length);
                                 length = 0;
                             }
 
@@ -4785,7 +4785,7 @@
                         this._totals[field]++;
                         break;
                     default:
-                        Report.error("REPORTAPI: Math expression id is wrong", this._math[i][0], " on ", field);
+                        Report.error("REPORTAPI: Math expression id is wrong" + this._math[i][0] + " on " + field);
                 }
             }
         },
@@ -4808,14 +4808,14 @@
                 if (curMode === reportRenderingMode.UNDEFINED) {
                     this._reportRenderMode(reportRenderingMode.ASYNC);
                 } else if (curMode !== reportRenderingMode.ASYNC) {
-                    Report.error("REPORTAPI: You have attempted to add a ASYNCHRONOUS ",typeFunction.toUpperCase(),"function to a report that already has a SYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this",typeFunction.toUpperCase(),"function and leaving the report SYNCHRONOUS!");
+                    Report.error("REPORTAPI: You have attempted to add a ASYNCHRONOUS " + typeFunction.toUpperCase() + "function to a report that already has a SYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this" + typeFunction.toUpperCase() + "function and leaving the report SYNCHRONOUS!");
                     return false;
                 }
             } else {
                 if (curMode === reportRenderingMode.UNDEFINED) {
                     this._reportRenderMode(reportRenderingMode.SYNC);
                 } else if (curMode !== reportRenderingMode.SYNC) {
-                    Report.error("REPORTAPI: You have attempted to add a SYNCHRONOUS",typeFunction.toUpperCase(),"function to a report that already has a ASYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this", typeFunction.toUpperCase(),"function and leaving the report ASYNCHRONOUS!");
+                    Report.error("REPORTAPI: You have attempted to add a SYNCHRONOUS" + typeFunction.toUpperCase() + "function to a report that already has a ASYNCHRONOUS function added to it.  The report MUST be either fully ASYNCHRONOUS or fully SYNCHRONOUS, otherwise issues will occur, so we are ignoring this" + typeFunction.toUpperCase() + "function and leaving the report ASYNCHRONOUS!");
                     return false;
                 }
             }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://github.com/Nathanaela/fluentreports/issues"
   },
   "dependencies": {
-    "@darkguardace/pdfkit": "^0.8.3"
+    "pdfkit": "KellPro/pdfkit"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://github.com/Nathanaela/fluentreports/issues"
   },
   "dependencies": {
-    "pdfkit": "^0.8.3"
+    "@darkguardace/pdfkit": "^0.8.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://github.com/Nathanaela/fluentreports/issues"
   },
   "dependencies": {
-    "pdfkit": "^0.7.2"
+    "pdfkit": "^0.8.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there, Nathanael!  I hope that you have been doing well.

This pull request will move to the KellPro version of PDFKit, which includes a couple of fixes for wrapping bugs.  These changes have been accepted into the PDFKit repo, but it seems that their NPM package hasn't been updated in about a year.

https://github.com/KellPro/pdfkit/commit/d8eb478e8089344d8c70bc59e58a708ca7c235f3
https://github.com/KellPro/pdfkit/commit/b91561bc1493856617faa2aabd7c3220b73f1dd5

Also included is a fix to the Fluent Reports string length checking code, so that it more closely mirrors that of PDFKit.  This difference was causing some band items to wrap when they should have been truncated, leading to overlapping data in several of our cases.  The change is detailed here https://github.com/NathanaelA/fluentreports/commit/30fce41a95ddf92ac8ff46c999ba20804cf3da7d.

Please let me know if you see anything that needs to be changed - thank you, sir!