### PR TITLE
Fix a typo with wrapping commit

### DIFF
--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -2299,7 +2299,7 @@
          */
         widthOfString: function (str, checkByWord) {
             if (!checkByWord) {
-                return this._PDF.widthOfString(curWord);
+                return this._PDF.widthOfString(str);
             } else {			
                 var splitString = str.split(' '),
                     curWord,


### PR DESCRIPTION
I missed this when re-implementing the default `widthOfString()` functionality.  Any calls to the method were resulting in 'undefined', unless the checkByWord option was enabled.