### PR TITLE
Fix additional wrapping bug

### DIFF
--- a/lib/fluentReports.js
+++ b/lib/fluentReports.js
@@ -1834,8 +1834,10 @@
         font: function (name, size) {
             try {
                 if (name && name.normal) {
+                    this._font = name.normal;
                     this._PDF.font(name.normal, size);
                 } else {
+                    this._font = name;
                     this._PDF.font(name, size);
                 }
                 // The actual Font name may be different than we registered it as; so we need to register in our list it...
@@ -3551,16 +3553,33 @@
 
             var maxLines = 1, curLines, maxFontSize= 1, bp = borderPadding * 2;
 
-            var originalFontSize = this.fontSize();
+            var originalFontSize = this.fontSize(),
+                originalFont = this._font;
             for (var i = 0; i < len; i++) {
                 data[i].data = this._processText(data[i].data);
                 var curFontSize = data[i].fontSize || data[i].fontsize || originalFontSize;
                 if (curFontSize > maxFontSize) {
                     maxFontSize = curFontSize;
                 }
+
+                var cellBolded;
+                if (data[i].fontbold || data[i].fontBold) {
+                  cellBolded = true;
+                }
+                if (cellBolded) {
+                  this.fontBold();
+                }
+
                 this._PDF.fontSize(curFontSize);
 
                 curLines = formatText.call(this, data[i], (data[i].width || defaultSize) - bp, lineData);
+
+                if (cellBolded) {
+                  if (originalFont) {
+                    this.font(originalFont);
+                  }
+                }
+
                 if (curLines > maxLines) {
                     maxLines = curLines;
                 }


### PR DESCRIPTION
Hello again, @NathanaelA!

This commit fixes another wrapping bug.  The symptom is similar to what the last commit fixed - where lines would sometimes wrap and overlap onto the line below - but the cause is different.  The `_cleanData()` process was not taking into account whether the specific cell was bolded, which can result in fewer maxLines being allotted than is actually necessary, if the text being bold pushes it over the cell width.

- `font()` now saves the new font to this._font
- `_cleanData()`now saves the original font before processing cells, using the value saved in `font()`
- Each cell now bolds as necessary, then resets to the original font afterwards